### PR TITLE
update toturial instruction url

### DIFF
--- a/tutorials/java/group-call/README.md
+++ b/tutorials/java/group-call/README.md
@@ -6,5 +6,5 @@ Kurento Java Tutorial: WebRTC many to many video call.
 Running this tutorial
 ---------------------
 
-In order to run this tutorial, please read the following [instructions](https://kurento.openvidu.io/docs/current/tutorials/java/tutorial-groupcall.html)
+In order to run this tutorial, please read the following [instructions](https://doc-kurento.readthedocs.io/en/latest/tutorials/java/tutorial-groupcall.html)
 


### PR DESCRIPTION
I hve update the instruciton url for the java tutorial for group-call

## What is the current behavior you want to change?
I got a 404.


## What is the new behavior provided by this change?
No 404 HTTP error code.


## How has this been tested?
I opened the site.


## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read the [Contribution Guidelines](https://github.com/Kurento/kurento/blob/main/.github/CONTRIBUTING.md)

