### PR TITLE
RecorderEndpoint: Parse and use username/password from URLs

### DIFF
--- a/server/module-core/src/gst-plugins/commons/kmsutils.c
+++ b/server/module-core/src/gst-plugins/commons/kmsutils.c
@@ -56,20 +56,6 @@ kms_utils_debug_graph_delay (GstBin * bin, guint interval)
 }
 
 gboolean
-kms_is_valid_uri (const gchar * url)
-{
-  gboolean ret;
-  GRegex *regex;
-
-  regex = g_regex_new ("^(?:((?:https?):)\\/\\/)([^:\\/\\s]+)(?::(\\d*))?(?:\\/"
-      "([^\\s?#]+)?([?][^?#]*)?(#.*)?)?$", 0, 0, NULL);
-  ret = g_regex_match (regex, url, G_REGEX_MATCH_ANCHORED, NULL);
-  g_regex_unref (regex);
-
-  return ret;
-}
-
-gboolean
 gst_element_sync_state_with_parent_target_state (GstElement * element)
 {
   GstElement *parent;

--- a/server/module-core/src/gst-plugins/commons/kmsutils.h
+++ b/server/module-core/src/gst-plugins/commons/kmsutils.h
@@ -32,7 +32,6 @@ gboolean kms_element_for_each_sink_pad (GstElement * element,
   KmsPadCallback action, gpointer data);
 
 void kms_utils_debug_graph_delay (GstBin * bin, guint interval);
-gboolean kms_is_valid_uri (const gchar * url);
 
 gboolean gst_element_sync_state_with_parent_target_state (GstElement * element);
 

--- a/server/module-core/src/server/implementation/objects/UriEndpointImpl.cpp
+++ b/server/module-core/src/server/implementation/objects/UriEndpointImpl.cpp
@@ -53,8 +53,10 @@ Both username and password fields should be provided in URL-encoded form:
 
     rtsp://us%3Aer:p%40ssword@example.com/test.mp4?user=token/s3/request&uri=umsp://example.com:1234/
 
-GStreamer will use `:` and `@` to break the string, and perform URL-decoding on
-the resulting fields.
+GStreamer's `rtspsrc` uses the function `gst_rtsp_url_parse()` to break the string at the points
+where `@` and `:` delimit username and password fields, then performs URL-decoding on those fields.
+
+See: https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/blob/1.16/gst-libs/gst/rtsp/gstrtspurl.c#L101
 */
 
 void UriEndpointImpl::checkUri ()


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/kurento/blob/main/.github/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
RecorderEndpoint is not able to push to a basic auth-protected HTTP server, because the GSTreamer element `curlhttpsink` doesn't parse them from the URL, instead it expects them to be set as properties.


## What is the new behavior provided by this change?
Use GstUri to parse the destination URL and extract the `username:password` field (called "*userinfo*").

Then, split the userinfo from the colon (`:`).

Lastly, URL-decode each of the resulting parts.

NOTE: GStreamer 1.16 (Ubuntu 20.04) does NOT support extracting a URL-encoded userinfo field. This means that the username and password will be already decoded, and the splitting on "`:`" will happen at the first colon found, which won't work if the username itself had a colon.

So, until we update to a newer Ubuntu/GStreamer version:

**THE USERNAME CANNOT CONTAIN A COLON**.

Also delete the unneeded function `kms_is_valid_uri()`. Better to delegate that check to the GstUri class constructor, which validates the URI and decides if it is valid or not.


## How has this been tested?
Basic auth protected Python http-server.


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [Contribution Guidelines](https://github.com/Kurento/kurento/blob/main/.github/CONTRIBUTING.md)
- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have written new tests for the changes, as applicable, and have successfully run them locally

Resolves https://github.com/Kurento/kurento/issues/42
