### PR TITLE
added function to server side dump dot for pipeline and media elements

### DIFF
--- a/server/module-core/src/server/implementation/DotGraph.cpp
+++ b/server/module-core/src/server/implementation/DotGraph.cpp
@@ -61,4 +61,15 @@ generateDotGraph (GstBin *bin, std::shared_ptr<GstreamerDotDetails> details)
   return retString;
 }
 
+void
+dumpDotGraph (GstBin *bin, std::shared_ptr<GstreamerDotDetails> details, std::string name)
+{
+  GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS (
+      bin,
+      convert_details (details),
+      name.c_str ()
+  );
+}
+
+
 } /* kurento */

--- a/server/module-core/src/server/implementation/DotGraph.hpp
+++ b/server/module-core/src/server/implementation/DotGraph.hpp
@@ -28,6 +28,9 @@ namespace kurento
 std::string
 generateDotGraph (GstBin *bin, std::shared_ptr<GstreamerDotDetails> details);
 
+void
+dumpDotGraph (GstBin *bin, std::shared_ptr<GstreamerDotDetails> details, std::string name);
+
 } /* kurento */
 
 #endif /* __KMS_DOT_GRAPH_H__ */

--- a/server/module-core/src/server/implementation/objects/HubImpl.cpp
+++ b/server/module-core/src/server/implementation/objects/HubImpl.cpp
@@ -43,6 +43,16 @@ std::string HubImpl::getGstreamerDot()
       std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
 }
 
+void HubImpl::dumpGstreamerDot ()
+{
+  dumpGstreamerDot (std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
+}
+
+void HubImpl::dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails> details)
+{
+  dumpDotGraph (GST_BIN(element), details, getId());
+}
+
 HubImpl::HubImpl (const boost::property_tree::ptree &config,
                   std::shared_ptr<MediaObjectImpl> parent,
                   const std::string &factoryName) : MediaObjectImpl (config, parent)

--- a/server/module-core/src/server/implementation/objects/HubImpl.hpp
+++ b/server/module-core/src/server/implementation/objects/HubImpl.hpp
@@ -49,6 +49,10 @@ public:
   virtual std::string getGstreamerDot (std::shared_ptr<GstreamerDotDetails>
                                        details);
 
+  virtual void dumpGstreamerDot ();
+  virtual void dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails>
+                                       details);
+
   /* Next methods are automatically implemented by code generator */
   virtual bool connect (const std::string &eventType,
                         std::shared_ptr<EventHandler> handler);

--- a/server/module-core/src/server/implementation/objects/MediaElementImpl.cpp
+++ b/server/module-core/src/server/implementation/objects/MediaElementImpl.cpp
@@ -1270,6 +1270,17 @@ std::string MediaElementImpl::getGstreamerDot()
       std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
 }
 
+void MediaElementImpl::dumpGstreamerDot ()
+{
+  dumpGstreamerDot (std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
+}
+
+void MediaElementImpl::dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails> details)
+{
+  dumpDotGraph (GST_BIN(element), details, getId());
+}
+
+
 int
 MediaElementImpl::getEncoderBitrate ()
 {

--- a/server/module-core/src/server/implementation/objects/MediaElementImpl.hpp
+++ b/server/module-core/src/server/implementation/objects/MediaElementImpl.hpp
@@ -117,6 +117,10 @@ public:
   virtual std::string getGstreamerDot (std::shared_ptr<GstreamerDotDetails>
                                        details) override;
 
+  virtual void dumpGstreamerDot ();
+  virtual void dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails>
+                                       details);
+
   bool isMediaFlowingIn (std::shared_ptr<MediaType> mediaType) override;
   bool isMediaFlowingIn (std::shared_ptr<MediaType> mediaType,
                          const std::string &sinkMediaDescription) override;

--- a/server/module-core/src/server/implementation/objects/MediaPipelineImpl.cpp
+++ b/server/module-core/src/server/implementation/objects/MediaPipelineImpl.cpp
@@ -76,6 +76,16 @@ std::string MediaPipelineImpl::getGstreamerDot()
       std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
 }
 
+void MediaPipelineImpl::dumpGstreamerDot ()
+{
+  dumpGstreamerDot (std::make_shared<GstreamerDotDetails>(GstreamerDotDetails::SHOW_VERBOSE));
+}
+
+void MediaPipelineImpl::dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails> details)
+{
+  dumpDotGraph (GST_BIN(pipeline), details, getId());
+}
+
 bool
 MediaPipelineImpl::getLatencyStats ()
 {

--- a/server/module-core/src/server/implementation/objects/MediaPipelineImpl.hpp
+++ b/server/module-core/src/server/implementation/objects/MediaPipelineImpl.hpp
@@ -50,6 +50,10 @@ public:
   virtual std::string getGstreamerDot (std::shared_ptr<GstreamerDotDetails>
                                        details);
 
+  virtual void dumpGstreamerDot ();
+  virtual void dumpGstreamerDot (std::shared_ptr<GstreamerDotDetails>
+                                       details);
+
   virtual bool getLatencyStats ();
   virtual void setLatencyStats (bool latencyStats);
 

--- a/server/module-core/src/server/interface/core.kmd.json
+++ b/server/module-core/src/server/interface/core.kmd.json
@@ -346,6 +346,29 @@ It connects several :rom:cls:`endpoints <Endpoint>` together
             "doc": "The dot graph.",
             "type": "String"
           }
+        },
+        {
+          "name": "dumpGstreamerDot",
+          "doc": "If GST_DEBUG_DUMP_DOT_DIR  environment variable is defined dumps in that directoy a file with the GStreamer dot of the Hub.
+          <p>The element can be queried for certain type of data:</p>
+<ul>
+  <li>SHOW_ALL: default value</li>
+  <li>SHOW_CAPS_DETAILS</li>
+  <li>SHOW_FULL_PARAMS</li>
+  <li>SHOW_MEDIA_TYPE</li>
+  <li>SHOW_NON_DEFAULT_PARAMS</li>
+  <li>SHOW_STATES</li>
+  <li>SHOW_VERBOSE</li>
+</ul>
+          ",
+          "params": [
+            {
+              "name": "details",
+              "type": "GstreamerDotDetails",
+              "doc": "Details of graph",
+              "optional": true
+            }
+          ]
         }
       ]
     },
@@ -478,6 +501,18 @@ It offers the methods needed to control the creation and connection of elements 
             "doc": "The dot graph.",
             "type": "String"
           }
+        },
+        {
+          "name": "dumpGstreamerDot",
+          "doc": "If GST_DEBUG_DUMP_DOT_DIR  environment variable is defined dumps in that directoy a file with the GStreamer dot of the pipeline",
+          "params": [
+            {
+              "name": "details",
+              "type": "GstreamerDotDetails",
+              "doc": "Details of graph",
+              "optional": true
+            }
+          ]
         }
       ]
     },
@@ -1236,6 +1271,29 @@ Pipeline, towards the associated producer. Only valid for video consumers.
               "name": "caps",
               "doc": "The format for the stream of video",
               "type": "VideoCaps"
+            }
+          ]
+        },
+        {
+          "name": "dumpGstreamerDot",
+          "doc": "If GST_DEBUG_DUMP_DOT_DIR  environment variable is defined dumps in that directoy a file with the GStreamer dot of the Media Element.
+          <p>The element can be queried for certain type of data:</p>
+<ul>
+  <li>SHOW_ALL: default value</li>
+  <li>SHOW_CAPS_DETAILS</li>
+  <li>SHOW_FULL_PARAMS</li>
+  <li>SHOW_MEDIA_TYPE</li>
+  <li>SHOW_NON_DEFAULT_PARAMS</li>
+  <li>SHOW_STATES</li>
+  <li>SHOW_VERBOSE</li>
+</ul>
+          ",
+          "params": [
+            {
+              "name": "details",
+              "type": "GstreamerDotDetails",
+              "doc": "Details of graph",
+              "optional": true
             }
           ]
         },


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/kurento/blob/main/.github/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
provide additional debug tools, specifically a better dump dot function than the one already included. The point is that previous function gets limited by the transport  to some maximum size in length. In some real pipelines this is not practical. So this funciton allows the server to write the dump dot files directly in theserver filesystem without limitations


## What is the new behavior provided by this change?
Adding some API to the interface that allows trigerring generatng a dot file in the server side.


## How has this been tested?
New test on the repository


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [Contribution Guidelines](https://github.com/Kurento/kurento/blob/main/.github/CONTRIBUTING.md)
- [X] I have added an explanation of what the changes do and why they should be included
- [X] I have written new tests for the changes, as applicable, and have successfully run them locally
