### PR TITLE
Remove calls to atoi/atol to avoid potential integer overflows/underflows

### DIFF
--- a/server/media-server/server/ResourceManager.cpp
+++ b/server/media-server/server/ResourceManager.cpp
@@ -42,7 +42,7 @@ get_int (std::string &str, char sep, int nToken)
 
     if (count++ == nToken) {
       str[end] = '\0';
-      return atol (&str.c_str() [start]);
+      return strtol (&str.c_str() [start], NULL, 10);
     }
 
     start = str.find_first_not_of (sep, end);

--- a/server/module-core/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/server/module-core/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -1210,7 +1210,7 @@ kms_base_rtp_endpoint_get_caps_from_rtpmap (const gchar * media,
 
   caps = gst_caps_new_simple ("application/x-rtp",
       "media", G_TYPE_STRING, media,
-      "payload", G_TYPE_INT, atoi (pt),
+      "payload", G_TYPE_INT, (gint)strtol(pt, NULL, 10),
       "clock-rate", G_TYPE_INT, clock_rate,
       "encoding-name", G_TYPE_STRING,
       kms_utils_get_caps_codec_name_from_sdp (codec_name), NULL);
@@ -1834,7 +1834,7 @@ kms_base_rtp_endpoint_get_caps_for_pt (KmsBaseRtpEndpoint * self, guint pt)
       GstCaps *caps;
       const gchar *payload = gst_sdp_media_get_format (media, j);
 
-      if (atoi (payload) != pt) {
+      if ((gint)strtol(payload, NULL, 10) != pt) {
         continue;
       }
 

--- a/server/module-core/src/gst-plugins/commons/sdp_utils.c
+++ b/server/module-core/src/gst-plugins/commons/sdp_utils.c
@@ -1018,8 +1018,10 @@ sdp_utils_get_pt_for_codec_name (const GstSDPMedia * media,
     }
 
     if (g_strcmp0 (found_codec_name, codec_name) == 0) {
-      GST_ERROR ("Found codec name pt is: %u", (gint)strtol(payload, NULL, 10));
-      pt = (gint)strtol(payload, NULL, 10);
+      gint parsed_pt = (gint)strtol(payload, NULL, 10);
+
+      GST_ERROR ("Found codec name pt is: %d", parsed_pt);
+      pt = parsed_pt;
     }
 
     g_free (found_codec_name);

--- a/server/module-core/src/gst-plugins/commons/sdp_utils.c
+++ b/server/module-core/src/gst-plugins/commons/sdp_utils.c
@@ -294,7 +294,7 @@ sdp_utils_sdp_media_get_rtpmap (const GstSDPMedia * media, const gchar * format)
         return NULL;
     }
 
-    pt = atoi (format);
+    pt = (gint)strtol(format, NULL, 10);
     if (pt > 34)
       return NULL;
 
@@ -904,7 +904,7 @@ sdp_utils_get_data_from_rtpmap (const gchar * rtpmap, gchar ** codec_name,
   }
 
   if (clock_rate) {
-    *clock_rate = atoi (tokens[1]);
+    *clock_rate = (gint)strtol(tokens[1], NULL, 10);
   }
 
   if (codec_name) {
@@ -928,7 +928,7 @@ sdp_utils_is_pt_in_fmts (const GstSDPMedia * media, gint pt)
   for (i = 0; i < len; i++) {
     gint payload;
 
-    payload = atoi (gst_sdp_media_get_format (media, i));
+    payload = (gint)strtol(gst_sdp_media_get_format (media, i), NULL, 10);
 
     if (payload == pt) {
       return TRUE;
@@ -973,7 +973,7 @@ sdp_utils_get_data_from_rtpmap_codec (const GstSDPMedia * media,
       continue;
     }
 
-    if (!sdp_utils_is_pt_in_fmts (media, atoi (attrs[0]))) {
+    if (!sdp_utils_is_pt_in_fmts (media, (gint)strtol(attrs[0], NULL, 10))) {
       /* pt is not in the offer */
       g_strfreev (attrs);
       continue;
@@ -985,7 +985,7 @@ sdp_utils_get_data_from_rtpmap_codec (const GstSDPMedia * media,
     }
 
     if (pt != NULL) {
-      *pt = atoi (attrs[0]);
+      *pt = (gint)strtol(attrs[0], NULL, 10);
     }
 
     found = TRUE;
@@ -1018,8 +1018,8 @@ sdp_utils_get_pt_for_codec_name (const GstSDPMedia * media,
     }
 
     if (g_strcmp0 (found_codec_name, codec_name) == 0) {
-      GST_ERROR ("Found codec name pt is: %u", atoi (payload));
-      pt = atoi (payload);
+      GST_ERROR ("Found codec name pt is: %u", (gint)strtol(payload, NULL, 10));
+      pt = (gint)strtol(payload, NULL, 10);
     }
 
     g_free (found_codec_name);
@@ -1048,7 +1048,7 @@ sdp_utils_get_abs_send_time_id (const GstSDPMedia * media)
 
     tokens = g_strsplit (attr, " ", 0);
     if (g_strcmp0 (RTP_HDR_EXT_ABS_SEND_TIME_URI, tokens[1]) == 0) {
-      gint ret = atoi (tokens[0]);
+      gint ret = (gint)strtol(tokens[0], NULL, 10);
 
       g_strfreev (tokens);
       return ret;

--- a/server/module-core/src/gst-plugins/commons/sdpagent/kmssdprtpavpmediahandler.c
+++ b/server/module-core/src/gst-plugins/commons/sdpagent/kmssdprtpavpmediahandler.c
@@ -386,7 +386,7 @@ kms_sdp_rtp_avp_media_handler_add_rtpmap_attrs (KmsSdpRtpAvpMediaHandler * self,
     guint pt;
 
     payload = g_array_index (media->fmts, gchar *, i);
-    pt = atoi (payload);
+    pt = (guint)strtoul(payload, NULL, 10);
 
     /* [rfc4566] rtpmap attribute can be omitted for static payload type  */
     /* numbers so it is completely defined in the RTP Audio/Video profile */
@@ -511,7 +511,7 @@ kms_sdp_rtp_avp_media_handler_format_supported (KmsSdpRtpAvpMediaHandler * self,
   gint pt;
 
   val = sdp_utils_get_attr_map_value (media, "rtpmap", fmt);
-  pt = atoi (fmt);
+  pt = (gint)strtol(fmt, NULL, 10);
 
   if (val == NULL) {
     /* Check if this is a static payload type so they do not need to be */
@@ -608,7 +608,7 @@ static gboolean
       /* Check if this is a static payload type so they do not need to be */
       /* set in an rtpmap attribute */
 
-      pt = atoi (fmt);
+      pt = (gint)strtol(fmt, NULL, 10);
       if (pt >= 0 && pt <= G_N_ELEMENTS (rtpmaps) && rtpmaps[pt] != NULL) {
         if (kms_sdp_rtp_avp_media_handler_encoding_supported (self, offer,
                 rtpmaps[pt], pt)) {

--- a/server/module-elements/src/gst-plugins/rtpendpoint/kmsrtpendpoint.c
+++ b/server/module-elements/src/gst-plugins/rtpendpoint/kmsrtpendpoint.c
@@ -35,7 +35,7 @@
 #include "kmsrtpsdescryptosuite.h"
 #include "kmsrandom.h"
 
-#include <stdlib.h> // atoi()
+#include <stdlib.h> // strtoul()
 
 #define PLUGIN_NAME "rtpendpoint"
 
@@ -991,7 +991,7 @@ kms_rtp_endpoint_start_transport_send (KmsBaseSdpEndpoint *base_sdp_endpoint,
       const gchar *attr_rtcp_port = gst_sdp_media_get_attribute_val(media,
           "rtcp");
       if (attr_rtcp_port != NULL) {
-        rtcp_port = (guint)atoi (attr_rtcp_port);
+        rtcp_port = (guint)strtoul (attr_rtcp_port, NULL, 10);
       }
 
       kms_rtp_base_connection_set_remote_info (conn,

--- a/server/module-elements/src/gst-plugins/webrtcendpoint/kmsicecandidate.c
+++ b/server/module-elements/src/gst-plugins/webrtcendpoint/kmsicecandidate.c
@@ -114,13 +114,13 @@ kms_ice_candidate_update_values (KmsIceCandidate * self)
   g_free (self->priv->related_addr);
 
   tmp = g_match_info_fetch_named (match_info, "port");
-  self->priv->port = atoi (tmp);
+  self->priv->port = (guint)strtoul(tmp, NULL, 10);
   g_free (tmp);
 
   self->priv->foundation = g_match_info_fetch_named (match_info, "foundation");
 
   tmp = g_match_info_fetch_named (match_info, "priority");
-  self->priv->priority = atoi (tmp);
+  self->priv->priority = (guint)strtoul(tmp, NULL, 10);
   g_free (tmp);
 
   tmp = g_match_info_fetch_named (match_info, "componentid");
@@ -182,7 +182,7 @@ kms_ice_candidate_update_values (KmsIceCandidate * self)
 
   tmp = g_match_info_fetch_named (match_info, "rport");
   if (tmp != NULL && g_strcmp0 (tmp, "") != 0) {
-    self->priv->related_port = atoi (tmp);
+    self->priv->related_port = (gint)strtol(tmp, NULL, 10);
   } else {
     self->priv->related_port = -1;
   }

--- a/server/module-elements/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
+++ b/server/module-elements/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
@@ -489,7 +489,7 @@ static void
 kms_ice_nice_agent_remove_stream (KmsIceBaseAgent * self, const char *stream_id)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   GST_LOG_OBJECT (self, "Remove data stream, stream_id: %u", id);
 
@@ -501,7 +501,7 @@ kms_ice_nice_agent_set_remote_credentials (KmsIceBaseAgent * self,
     const char *stream_id, const char *ufrag, const char *pwd)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   GST_LOG_OBJECT (self, "Set remote credentials, stream_id: %u", id);
 
@@ -514,7 +514,7 @@ kms_ice_nice_agent_get_local_credentials (KmsIceBaseAgent * self,
     const char *stream_id, gchar ** ufrag, gchar ** pwd)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   GST_LOG_OBJECT (self, "Get local credentials, stream_id: %u", id);
 
@@ -574,7 +574,7 @@ kms_ice_nice_agent_add_relay_server (KmsIceBaseAgent * self,
     KmsIceRelayServerInfo server_info)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (server_info.stream_id);
+  guint id = (guint)strtoul(server_info.stream_id, NULL, 10);
   NiceRelayType type = from_turn_protocol_to_nice_relay (server_info.type);
 
   GST_DEBUG_OBJECT (self, "Add relay server,"
@@ -601,7 +601,7 @@ kms_ice_nice_agent_start_gathering_candidates (KmsIceBaseAgent * self,
     const char *stream_id)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   gboolean ok = nice_agent_gather_candidates (nice_agent->priv->agent, id);
 
@@ -618,7 +618,7 @@ kms_ice_nice_agent_add_ice_candidate (KmsIceBaseAgent * self,
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
   NiceCandidate *nice_cand;
-  guint id = (guint) atoi (stream_id);
+  guint id = (guint) (guint)strtoul(stream_id, NULL, 10);
   gboolean ret;
   GSList *candidates;
   gchar *candidate_str;
@@ -671,7 +671,7 @@ kms_ice_nice_agent_get_default_local_candidate (KmsIceBaseAgent * self,
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
   NiceCandidate *nice_cand;
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
   KmsIceCandidate *ret;
 
   nice_cand =
@@ -691,7 +691,7 @@ kms_ice_nice_agent_get_local_candidates (KmsIceBaseAgent * self,
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
   GSList *ret = NULL;
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
   GSList *candidates;
   GSList *walk;
 
@@ -722,7 +722,7 @@ kms_ice_nice_agent_get_remote_candidates (KmsIceBaseAgent * self,
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
   GSList *ret = NULL;
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
   GSList *candidates;
   GSList *walk;
 
@@ -752,7 +752,7 @@ kms_ice_nice_agent_get_component_state (KmsIceBaseAgent * self,
     const char *stream_id, guint component_id)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
   NiceComponentState state;
 
   state = nice_agent_get_component_state (nice_agent->priv->agent, id,

--- a/server/module-elements/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
+++ b/server/module-elements/src/gst-plugins/webrtcendpoint/kmsiceniceagent.c
@@ -618,7 +618,7 @@ kms_ice_nice_agent_add_ice_candidate (KmsIceBaseAgent * self,
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (self);
   NiceCandidate *nice_cand;
-  guint id = (guint) (guint)strtoul(stream_id, NULL, 10);
+  guint id = (guint) strtoul(stream_id, NULL, 10);
   gboolean ret;
   GSList *candidates;
   gchar *candidate_str;

--- a/server/module-elements/src/gst-plugins/webrtcendpoint/kmswebrtctransportsinknice.c
+++ b/server/module-elements/src/gst-plugins/webrtcendpoint/kmswebrtctransportsinknice.c
@@ -66,7 +66,7 @@ kms_webrtc_transport_sink_nice_configure (KmsWebrtcTransportSink * self,
     KmsIceBaseAgent * agent, const char *stream_id, guint component_id)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (agent);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   g_object_set (G_OBJECT (self->sink),
       "agent", kms_ice_nice_agent_get_agent (nice_agent),

--- a/server/module-elements/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
+++ b/server/module-elements/src/gst-plugins/webrtcendpoint/kmswebrtctransportsrcnice.c
@@ -208,7 +208,7 @@ kms_webrtc_transport_src_nice_configure (KmsWebrtcTransportSrc * self,
     KmsIceBaseAgent * agent, const char *stream_id, guint component_id)
 {
   KmsIceNiceAgent *nice_agent = KMS_ICE_NICE_AGENT (agent);
-  guint id = atoi (stream_id);
+  guint id = (guint)strtoul(stream_id, NULL, 10);
 
   g_object_set (G_OBJECT (self->src),
       "agent", kms_ice_nice_agent_get_agent (nice_agent),

--- a/server/module-elements/src/server/implementation/objects/WebRtcEndpointImpl.cpp
+++ b/server/module-elements/src/server/implementation/objects/WebRtcEndpointImpl.cpp
@@ -281,8 +281,15 @@ void WebRtcEndpointImpl::onIceComponentStateChanged (gchar *sessId,
                              <std::string, std::shared_ptr <IceConnection>> (key, connectionState) );
 
   try {
+    int streamId_int = 0;
+    try {
+      streamId_int = std::stoi(streamId);
+    } catch (const std::invalid_argument& ia) {
+      GST_ERROR("Invalid streamId for IceComponentStateChanged event: %s", streamId);
+    }
+
     IceComponentStateChanged event (shared_from_this (),
-        IceComponentStateChanged::getName (), atoi (streamId), componentId,
+        IceComponentStateChanged::getName (), streamId_int, componentId,
         std::shared_ptr<IceComponentState> (componentState_event));
     sigcSignalEmit(signalIceComponentStateChanged, event);
   } catch (const std::bad_weak_ptr &e) {


### PR DESCRIPTION
Removing calls to `atoi` or `atoil` that could lead to integer overflow/underflow (as reported by security scanner).


## What is the current behavior you want to change?

No change in behaviour expected

## What is the new behavior provided by this change?

No change in behaviour expected

## How has this been tested?

Unit tests execution.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->

